### PR TITLE
drop `rl_benchmarks_release` from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,29 +317,6 @@ sudo apt install libpixman-1-0
 All the accessible versions are stored in [this website](https://pkgs.org/download/libpixman-1-0).
 You can eventually run `apt-get check` to check for broken dependencies.
 
-
-### Installing `rl_benchmarks` package
-
-Create a dedicated conda environment:
-
-```bash
-conda create -n rl_benchmarks python=3.8
-conda activate rl_benchmarks
-````
-
-Install `rl_benchmarks` package and its dependencies using the `install.sh` file.
-
-```bash
-cd /workspace
-git clone https://github.com/owkin/rl_benchmarks_release.git
-cd ./rl_benchmarks_release
-bash install.sh
-```
-
-Once the installation and data download steps are completed, you finally need to edit the `conf.yaml` file so that to specify:
-- `logs_save_dir`: directory for cross-validation experiments logs
-- `data_dir`: root directory that contains the downloaded data. If you downloaded the data in `/home/user/downloaded_data/` folder, then this should be the `data_dir`.
-
 ### Run tests (10 minutes)
 
 Once data has been downloaded and the previous installation steps done, you can

--- a/README.md
+++ b/README.md
@@ -317,6 +317,29 @@ sudo apt install libpixman-1-0
 All the accessible versions are stored in [this website](https://pkgs.org/download/libpixman-1-0).
 You can eventually run `apt-get check` to check for broken dependencies.
 
+
+### Installing `rl_benchmarks` package within this repo
+
+Create a dedicated conda environment (optional):
+
+```bash
+conda create -n rl_benchmarks python=3.8
+conda activate rl_benchmarks
+```
+
+Install `rl_benchmarks` package and its dependencies using the `install.sh` file.
+
+```bash
+git clone https://github.com/owkin/HistoSSLscaling.git
+cd ./HistoSSLscaling
+# Install the RL_benchmarks repository (in editable mode) together with other requirements
+python -m pip install -e .  -r requirements.txt 
+```
+
+Once the installation and data download steps are completed, you finally need to edit the `conf.yaml` file so that to specify:
+- `logs_save_dir`: directory for cross-validation experiments logs
+- `data_dir`: root directory that contains the downloaded data. If you downloaded the data in `/home/user/downloaded_data/` folder, then this should be the `data_dir`.
+
 ### Run tests (10 minutes)
 
 Once data has been downloaded and the previous installation steps done, you can

--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,0 @@
-python -m pip install -r requirements.txt  # Other requirements
-python -m pip install -e .  # Install the RL_benchmarks repository (in editable mode)


### PR DESCRIPTION
The referred repository does not exist anymore, and in fact, it seems that the related code was moved inside this repo as `rl_benchmarks`, so having this section is confusing, and I would suggest dropping it... :flamingo: 